### PR TITLE
Upgrade AMI IDs. Add support to 2 new AWS Regions

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ With this template, we continue with our mission to make [distributed deep learn
 ## What's New?  
 We've updated the AWS CloudFormation Deep Learning template to add some exciting new features and capabilities.
 
+* We now support 5 AWS regions - us-east-1, us-east-2, us-west-2, eu-west-1 and ap-southeast-2.
+
 *  We've enhanced the AWS CloudFormation Deep Learning template with automation that continues stack creation even if the provisioned number of worker instances falls short of the desired count. In the previous version of the template, if one of the worker instances failed to be provisioned, for example, if it a hit account limit, AWS CloudFormation rolled back the stack and required you to adjust your desired count and restart the stack creation process. The new template includes a function that automatically adjusts the count down and proceeds with setting up the rest of the cluster (stack).  
 
 *  We now support creating a cluster of CPU Amazon EC2 instance types. 
@@ -16,8 +18,6 @@ We've updated the AWS CloudFormation Deep Learning template to add some exciting
 	*  Using Amazon EFS doesn't degrade performance for densely packed files (for example, .rec files containing image data).  
 
 * We now support creating a cluster of instances running Ubuntu. See the [Ubuntu Deep Learning AMI](https://aws.amazon.com/marketplace/pp/B06VSPXKDX).
-
-* We now support 5 AWS regions - us-east-1, us-east-2, us-west-2, eu-west-1 and ap-southeast-2.
 
 ## EC2 Cluster Architecture 
 The following architecture diagram shows the EC2 cluster infrastructure.  

--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ We've updated the AWS CloudFormation Deep Learning template to add some exciting
 
 * We now support creating a cluster of instances running Ubuntu. See the [Ubuntu Deep Learning AMI](https://aws.amazon.com/marketplace/pp/B06VSPXKDX).
 
+* We now support 5 AWS regions - us-east-1, us-east-2, us-west-2, eu-west-1 and ap-southeast-2.
+
 ## EC2 Cluster Architecture 
 The following architecture diagram shows the EC2 cluster infrastructure.  
 ![](images/Slide0.png)  

--- a/cfn-bootstrap/dl_cfn_setup_v2.py
+++ b/cfn-bootstrap/dl_cfn_setup_v2.py
@@ -1,0 +1,439 @@
+#!/usr/bin/python
+
+#  Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+#  Licensed under the Amazon Software License (the "License").
+#  You may not use this file except in compliance with the License.
+#  A copy of the License is located at
+#
+#  http://aws.amazon.com/asl/
+#
+#  or in the "license" file accompanying this file. This file is distributed
+#  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+#  express or implied. See the License for the specific language governing
+#  permissions and limitations under the License.
+
+import os
+import boto
+import boto.utils
+from sets import Set
+import logging
+import json
+import subprocess
+import time
+import sys
+import datetime
+import pwd
+import grp
+import os
+import boto.ec2
+import boto.ec2.autoscale
+import boto.sqs
+import boto.cloudformation
+
+HOST_FILE = '/etc/hosts'
+WORKER_FILE = '/opt/deeplearning/workers'
+SLEEP_INTERVAL_IN_SECS = 30
+SQS_RECEIVE_INTERVAL_IN_SECS = 20
+AWS_DL_NODE_TYPE = None
+AWS_DL_MASTER_QUEUE = None
+AWS_DL_WORKER_QUEUE = None
+AWS_DL_SETUP_TIMEOUT = None
+AWS_DL_MASTERLAUNCH_TIMEOUT = None
+AWS_DL_STACK_ID = None
+AWS_DL_WAIT_HANDLE = None
+AWS_REGION = None
+AWS_DL_ROLE_NAME = None
+AWS_DL_DEFAULT_USER = None
+EFS_MOUNT = None
+CFN_PATH = None
+
+AWS_GPU_INSTANCE_TYPES = [ "g2.2xlarge", "g2.8xlarge", "p2.xlarge", "p2.8xlarge", "p2.16xlarge" ]
+
+'''
+Setup Logger and LogLevel
+'''
+def setup_logging(log_loc='/var/log'):
+
+    log_file = '{}/dl_cfn_setup.log'.format(log_loc)
+    LOGGER = logging.getLogger('dl-cfn-setup')
+    LOGGER.setLevel(logging.INFO)
+    formatter = logging.Formatter('%(asctime)s %(levelname)s: %(filename)s:%(lineno)d %(message)s')
+    file_handler = logging.FileHandler(log_file)
+    file_handler.setFormatter(formatter)
+    console_handler = logging.StreamHandler()
+    console_handler.setFormatter(formatter)
+
+    LOGGER.addHandler(file_handler)
+    LOGGER.addHandler(console_handler)
+
+    return LOGGER
+
+def ping_host(hostname):
+    res = os.system("ping -c 1 -w 10 " + hostname)
+    return res == 0
+
+def get_gpu_count():
+    LOGGER.info('setup_gpu_count')
+
+    instance_type = boto.utils.get_instance_metadata()['instance-type']
+    if instance_type not in AWS_GPU_INSTANCE_TYPES:
+        LOGGER.info('Not a GPU Instance, number of GPUs: {}'.format(0))
+        return 0
+    try:
+        output = subprocess.check_output(['nvidia-smi', '-L'])
+        gpu_count = output.count('\n')
+        LOGGER.info("number of GPUs:{}".format(gpu_count))
+        return gpu_count
+    except subprocess.CalledProcessError as e:
+        LOGGER.exception("Error executing nvidia-smi: {}".format(e))
+        return 0
+
+def setup_env_variables(master_instance_ip, worker_instance_ips, default_user, efs_mount):
+    LOGGER.info("setup_env_variables")
+
+    with open(HOST_FILE, 'a') as hosts, open(WORKER_FILE, 'w+') as w:
+        hosts.write("{} deeplearning-master\n".format(master_instance_ip))
+        worker_index=1
+        for worker_ip in worker_instance_ips:
+            hosts.write("{} deeplearning-worker{}\n".format(worker_ip, worker_index) )
+            w.write("deeplearning-worker{}\n".format(worker_index))
+            worker_index += 1
+
+    gpu_count = get_gpu_count()
+    with open("/etc/profile.d/deeplearning.sh", "a") as f:
+        num_workers = sum(1 for line in open(WORKER_FILE, "r"))
+        f.write("export DEEPLEARNING_WORKERS_COUNT={}\n".format(num_workers))
+        f.write("export DEEPLEARNING_WORKERS_PATH={}\n".format(WORKER_FILE))
+        f.write("export DEEPLEARNING_WORKER_GPU_COUNT={}\n".format(gpu_count))
+        f.write("export EFS_MOUNT={}\n".format(efs_mount))
+
+    #change ownership to ec2-user
+    uid = pwd.getpwnam(default_user).pw_uid
+    gid = grp.getgrnam(default_user).gr_gid
+    os.chown(WORKER_FILE, uid, gid)
+
+    return
+
+'''
+wait for asg setup success message from the lambda function
+message will be of the format
+{"min": 1, "desired": 1, "max": 1, "launched": 1, "status": "success", "asg": "cfn-test-WorkerAutoScalingGroup-1HPKVL6PJEVQS", "event": "asg-setup"}
+'''
+def wait_until_asg_success(master_queue_name, region, timeout):
+    LOGGER.info('wait_until_asg_success on queue_name:{}, timeout:{}'.format(master_queue_name, timeout))
+    sqs_con = boto.sqs.connect_to_region(region_name=region)
+    sqs_queue = sqs_con.get_queue(queue_name = master_queue_name)
+    asg_success_message = {}
+
+    start_time = time.time()
+    next_execution_ts = start_time
+
+    while True:
+        LOGGER.info('checking autoscaling group success message at {}'.format(datetime.datetime.now()))
+
+        recvd_messages = sqs_con.receive_message(queue=sqs_queue,number_messages=10, visibility_timeout=60)
+        LOGGER.info('number of messages received: {}'.format(len(recvd_messages)))
+        for msg in recvd_messages:
+            msg_body = msg.get_body()
+            LOGGER.info('received message with body:{}'.format(msg_body))
+            try:
+                content = json.loads(msg_body)
+                if content is not None and content['event'] == 'asg-setup' and content['status'] == 'success':
+                    # http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/standard-queues.html#standard-queues-at-least-once-delivery
+                    # ignore duplicate message
+                    if content['asg'] not in asg_success_message:
+                        LOGGER.info('autosclaing_group: {} succeeded at {}'.format(content['asg'], datetime.datetime.now()))
+                        asg_success_message[content['asg']] = content
+                    else:
+                        LOGGER.info('received duplicate sqs message for {} at {}'.format(content['asg'], datetime.datetime.now()))
+                sqs_con.delete_message(queue=sqs_queue, message=msg)
+            except (TypeError, KeyError) as e:
+                LOGGER.exception(e)
+                LOGGER.error(msg)
+                continue
+
+        if len(asg_success_message) is 2:
+            LOGGER.info('status of all autoscaling_groups received')
+            break
+
+        next_execution_ts = next_execution_ts + SLEEP_INTERVAL_IN_SECS
+        if (next_execution_ts > (start_time + timeout)):
+            LOGGER.info('timeout while checking asg status after {} seconds'.format(timeout))
+            break
+
+        LOGGER.info('not received all autoscaling group success at {}, WAITING :{}'.format(datetime.datetime.now(), SLEEP_INTERVAL_IN_SECS))
+        time.sleep(next_execution_ts - time.time())
+
+    return asg_success_message
+
+def wait_for_worker_setup_message(worker_queue_name, timeout, region):
+    LOGGER.info('wait_for_worker_setup_message, worker_queue_name:{}, timeout:{}'.format(worker_queue_name, timeout))
+    sqs_con = boto.sqs.connect_to_region(region_name=region)
+    sqs_queue = sqs_con.get_queue(queue_name = worker_queue_name)
+
+    start_time = time.time()
+    next_execution_ts = start_time
+
+    while True:
+        LOGGER.info('checking for worker_setup message at {}'.format(datetime.datetime.now()))
+        #visibility_timeout is set to 0, so that other workers can simultaneously act on this message
+        recvd_messages = sqs_con.receive_message(queue=sqs_queue,number_messages=10, visibility_timeout=0)
+        LOGGER.info('number of messages received: {}'.format(len(recvd_messages)))
+        for msg in recvd_messages:
+            msg_body = msg.get_body()
+            LOGGER.info('received message with body:{}'.format(msg_body))
+            try:
+                content = json.loads(msg_body)
+                if content is not None and content['event'] == 'worker-setup':
+                    LOGGER.info('received worker-setup success message: {}'.format(content))
+                    # do not delete the message, other workers need to consume this.
+                    return content['master-ip'], content['worker-ips']
+                else:
+                    #don't act on other messages
+                    continue
+            except (TypeError, KeyError) as e:
+                LOGGER.error(e)
+                LOGGER.error(msg)
+                continue
+
+        next_execution_ts = next_execution_ts + SLEEP_INTERVAL_IN_SECS
+        if (next_execution_ts > (start_time + timeout)):
+            LOGGER.info('did not receive worker-setup success even after {} seconds'.format(timeout))
+            return None
+
+        LOGGER.info('worker setup not complete is not complete at {}'.format(datetime.datetime.now()))
+        time.sleep(next_execution_ts - time.time())
+
+    return None
+
+def wait_until_instances_active(autoscaling_groups, timeout, region):
+    LOGGER.info('wait_until_instances_active, asgs:{}, timeout:{}'.format(autoscaling_groups, timeout))
+
+    autoscale_con = boto.ec2.autoscale.connect_to_region(region_name=region)
+    ec2_con = boto.ec2.connect_to_region(region_name=region)
+    start_time = time.time()
+    next_execution_ts = start_time
+    master_instance_ids = []
+    worker_instance_ids = []
+    master_instances = {}
+    worker_instances = {}
+    try:
+        # http://boto.cloudhackers.com/en/latest/ref/autoscale.html#boto.ec2.autoscale.group.AutoScalingGroup
+        # does not specify how to get the next token for pagination,
+        # since there are only 2 groups in our case, we will assume they will be returned in one call
+        groups = autoscale_con.get_all_groups(names=autoscaling_groups)
+
+        for asg in groups:
+            instance_ids=[]
+            for instance in asg.instances:
+                if instance.health_status == 'Healthy':
+                    instance_ids.append(instance.instance_id)
+
+            if 'master' in asg.name.lower():
+                master_instance_ids.extend(instance_ids)
+            else:
+                worker_instance_ids.extend(instance_ids)
+                LOGGER.info('from autoscale, found instances:{} for asg:{}'.format(instance_ids, asg.name))
+
+        LOGGER.info('worker_asg_instane_ids:{}, master_ids:{}'.format(worker_instance_ids, master_instance_ids))
+        next_token = None
+        pending_instance_ids = master_instance_ids + worker_instance_ids
+
+        while(True):
+            LOGGER.info('getting ec2 instance info:{}'.format(pending_instance_ids))
+            reservations = ec2_con.get_all_reservations(instance_ids = pending_instance_ids, next_token = next_token)
+            next_token = reservations.next_token
+
+            for r in reservations:
+                for i in r.instances:
+                    if i.state.lower() == 'running':
+                        if i.id in master_instance_ids:
+                            LOGGER.info('master instance in running state, id:{}, ip:{}'.format(i.id, i.private_ip_address))
+                            master_instances[i.id] = i.private_ip_address
+                        elif i.id in worker_instance_ids:
+                            LOGGER.info('worker instance in running state, id:{}, ip:{}'.format(i.id, i.private_ip_address))
+                            worker_instances[i.id] = i.private_ip_address
+                            LOGGER.info('worker:{}'.format(worker_instances))
+                        pending_instance_ids.remove(i.id)
+                    elif i.state.lower() == 'pending':
+                        LOGGER.info('instance is still in pending state, instance id:{}'.format(i.id))
+                        continue
+
+            next_execution_ts = next_execution_ts + SLEEP_INTERVAL_IN_SECS
+            if (len(pending_instance_ids) == 0):
+                LOGGER.info('received info of all instances, master: {}, worker: {}'.format(master_instances, worker_instances))
+                break
+            elif (next_token is not None):
+                LOGGER.info('next_token is not None, will continue fetching more instances')
+                continue
+            elif (next_execution_ts < start_time + timeout):
+                LOGGER.error('Reached timeout, pending_instance_ids:{}, next_token:{}'.format(pending_instance_ids, next_token))
+                break
+            else:
+                LOGGER.info('not all instance info is available, pending: {}, waiting for {} seconds'.format(pending_instance_ids, SLEEP_INTERVAL_IN_SECS))
+                time.sleep(next_execution_ts - time.time())
+
+        LOGGER.info('master: {}, worker: {}'.format(master_instances, worker_instances))
+        return master_instances, worker_instances
+    except Exception as e:
+        LOGGER.exception(e)
+        return ({},{})
+'''
+This method will send success signal to the wait handle url
+its assumed cfn-signal aws cli tool is available on the instance
+'''
+def send_cfn_success_signal(stack_id, wait_handle_url, aws_region, cfn_path):
+    try:
+        instance_id = boto.utils.get_instance_metadata()['instance-id']
+        cfn_success_signal_command = cfn_path + '/cfn-signal'
+        command_args = [cfn_success_signal_command, '--region', aws_region, '--stack', \
+        stack_id, '--success', 'true', '--id', instance_id, wait_handle_url]
+        LOGGER.info('{} command: {}'.format(cfn_success_signal_command, ' '.join(map(str, command_args))))
+        output = subprocess.check_output(command_args)
+        LOGGER.info(output)
+    except subprocess.CalledProcessError as e:
+        LOGGER.exception('FAILED to send cfn-signal')
+        sys.exit(1)
+    return
+
+'''
+waits for a message on SQS for asg setup complete and instances are active.
+fetches private ip addresses of the instances and sets up metadata
+'''
+def setup_worker_metadata(setup_timeout, master_queue_name, stack_id, region):
+    LOGGER.info('setup_worker_metadata')
+
+    start_time = time.time()
+    asg_setup_messages = wait_until_asg_success(master_queue_name, region, setup_timeout)
+    if len(asg_setup_messages) is not 2:
+        LOGGER.error('did not receive asg success message for all autoscaling_groups, received only: {}'.format(asg_setup_messages))
+        sys.exit(1)
+
+    master_asg_message = None
+    worker_asg_message = None
+    for key, value in asg_setup_messages.iteritems():
+        LOGGER.info('asg success message:{}'.format(value))
+        if 'master' in key.lower():
+            master_asg_message = value
+        else:
+            worker_asg_message = value
+
+    timeout = setup_timeout - (time.time() - start_time)
+    start_time = time.time()
+
+    (master_instances, worker_instances) = wait_until_instances_active([master_asg_message['asg'], worker_asg_message['asg']], timeout, region)
+    LOGGER.info('from wait_until_instances_active, master: {}, worker:{}'.format(master_instances, worker_instances))
+    if (len(master_instances) != 1):
+        LOGGER.error('expected single master, instead got instance ips:{}', master_instances)
+        sys.exit(1)
+    master_instance_ip = master_instances.values()[0]
+    worker_instance_ips = [master_instance_ip]
+
+    if len(worker_instances) is 0:
+        LOGGER.info('no worker is launched, using only master instance as worker')
+    else:
+        worker_instance_ips.extend(worker_instances.values())
+
+        if (len(worker_instances) != worker_asg_message['launched']):
+            LOGGER.error('expected {} number of instances to be running, instead got instance_ids: {}, ips: {}' \
+            .format(worker_asg_message['launched'], worker_instances.keys(), worker_instances.values()) )
+
+    worker_instance_ips = sorted(worker_instance_ips)
+
+    return master_instance_ip, worker_instance_ips
+
+def send_worker_setup_msg(worker_queue_name, master_instance_ip, worker_instance_ips, region):
+    LOGGER.info('send_worker_setup_msg:{}'.format(send_worker_setup_msg))
+
+    sqs_con = boto.sqs.connect_to_region(region_name=region)
+    sqs_queue = sqs_con.get_queue(queue_name = worker_queue_name)
+
+    worker_setup_message={'event' : 'worker-setup'}
+    worker_setup_message['master-ip'] = master_instance_ip
+    worker_setup_message['worker-ips'] = worker_instance_ips
+
+    LOGGER.info('sending worker-setup message:{}'.format(json.dumps(worker_setup_message)))
+    sqs_con.send_message(queue=sqs_queue, message_content=json.dumps(worker_setup_message))
+
+def check_instance_role_availability(role_name, timeout):
+    LOGGER.info('check_instance_role_availability, role_name:{}, timeout: {}'.format(role_name, timeout))
+
+    start_time = time.time()
+    next_execution_ts = start_time
+    while True:
+        LOGGER.info('checking presence of instance role: {}, @ :{}'.format(role_name, datetime.datetime.now()))
+
+        try:
+            metadata = boto.utils.get_instance_metadata(version='latest',timeout=30, num_retries=5)
+            instance_role = metadata['iam']['security-credentials'][role_name]
+            # we don't want to log the credentials
+            del instance_role['AccessKeyId']
+            del instance_role['SecretAccessKey']
+            del instance_role['Token']
+            LOGGER.info('SUCCESS getting instance role {}'.format(instance_role))
+            return True
+        except KeyError as e:
+            LOGGER.info('FAILED to get instance role: {} @ {}'.format(role_name, datetime.datetime.now()))
+            pass
+        next_execution_ts = next_execution_ts + SLEEP_INTERVAL_IN_SECS
+        if (next_execution_ts > (start_time + timeout)):
+            LOGGER.info('TIMEOUT while checking instance role after {} seconds'.format(timeout))
+            break
+
+        LOGGER.info('WAITING :{} to get instance_role:{} @ {}'.format(SLEEP_INTERVAL_IN_SECS, role_name, datetime.datetime.now()))
+        time.sleep(next_execution_ts - time.time())
+    return False
+
+LOGGER = setup_logging()
+def main():
+    LOGGER.info("main")
+
+    try:
+        AWS_DL_NODE_TYPE = os.environ["AWS_DL_NODE_TYPE"]
+        AWS_DL_MASTER_QUEUE = os.environ['AWS_DL_MASTER_QUEUE']
+        AWS_DL_WORKER_QUEUE = os.environ['AWS_DL_WORKER_QUEUE']
+        AWS_DL_WAITCONDITION_TIMEOUT = float(os.environ['AWS_DL_WAITCONDITION_TIMEOUT'])
+        AWS_DL_MASTERLAUNCH_TIMEOUT = float(os.environ['AWS_DL_MASTERLAUNCH_TIMEOUT'])
+        AWS_DL_STACK_ID = os.environ['AWS_DL_STACK_ID']
+        AWS_DL_WAIT_HANDLE = os.environ['AWS_DL_WAIT_HANDLE']
+        AWS_DL_ROLE_NAME = os.environ['AWS_DL_ROLE_NAME']
+        AWS_DL_DEFAULT_USER = os.environ['AWS_DL_DEFAULT_USER']
+        AWS_REGION = os.environ['AWS_REGION']
+        EFS_MOUNT = os.environ['EFS_MOUNT']
+        CFN_PATH = os.environ['CFN_PATH']
+
+        LOGGER.info('AWS_DL_NODE_TYPE:{}\n AWS_DL_MASTER_QUEUE:{}\n AWS_DL_WORKER_QUEUE:{}\n AWS_DL_WAITCONDITION_TIMEOUT:{}\n, AWS_DL_MASTERLAUNCH_TIMEOUT:{}\n AWS_DL_STACK_ID:{}\n \
+            AWS_DL_WAIT_HANDLE:{}\n AWS_DL_ROLE_NAME:{}\n AWS_REGION:{}, AWS_DL_DEFAULT_USER:{}, EFS_MOUNT:{}, CFN_PATH:{}\n'.format(AWS_DL_NODE_TYPE, AWS_DL_MASTER_QUEUE, AWS_DL_WORKER_QUEUE, \
+            AWS_DL_WAITCONDITION_TIMEOUT, AWS_DL_MASTERLAUNCH_TIMEOUT, AWS_DL_STACK_ID, AWS_DL_WAIT_HANDLE, AWS_DL_ROLE_NAME, AWS_REGION, AWS_DL_DEFAULT_USER, EFS_MOUNT, CFN_PATH)
+        )
+
+        # we want to make sure we finish before the timeout expires
+        setup_timeout = AWS_DL_WAITCONDITION_TIMEOUT - AWS_DL_MASTERLAUNCH_TIMEOUT
+        start_time = time.time()
+        check_instance_role_availability(AWS_DL_ROLE_NAME, setup_timeout)
+        setup_timeout = setup_timeout - (time.time() - start_time)
+
+        # get master ips
+        if (AWS_DL_NODE_TYPE.lower() == 'master'):
+            master_instance_ip, worker_instance_ips = setup_worker_metadata(setup_timeout, AWS_DL_MASTER_QUEUE, AWS_DL_STACK_ID, AWS_REGION)
+            setup_env_variables(master_instance_ip, worker_instance_ips, AWS_DL_DEFAULT_USER, EFS_MOUNT)
+            send_worker_setup_msg(AWS_DL_WORKER_QUEUE, master_instance_ip, worker_instance_ips, AWS_REGION)
+            send_cfn_success_signal(AWS_DL_STACK_ID, AWS_DL_WAIT_HANDLE, AWS_REGION, CFN_PATH)
+
+        elif (AWS_DL_NODE_TYPE.lower() == 'worker'):
+            master_instance_ip, worker_instance_ips = wait_for_worker_setup_message(AWS_DL_WORKER_QUEUE, setup_timeout, AWS_REGION)
+            if master_instance_ip is None or worker_instance_ips is None:
+                LOGGER.error('FAILED worker metadata setup : master_ip:{}, worker_ips:{}'.format(master_instance_ip, worker_instance_ips))
+                sys.exit(1)
+            setup_env_variables(master_instance_ip, worker_instance_ips, AWS_DL_DEFAULT_USER, EFS_MOUNT)
+        else:
+            LOGGER.error('unknown node type: {}'.format(AWS_DL_NODE_TYPE))
+            sys.exit(1)
+
+    except Exception as e:
+        LOGGER.exception(e)
+        sys.exit(1)
+
+if  __name__ =='__main__':
+    main()

--- a/cfn-template/deeplearning.template
+++ b/cfn-template/deeplearning.template
@@ -20,7 +20,7 @@
         "p2.16xlarge",
         "p2.8xlarge",
         "p2.xlarge",
-        "g2.8xlarge", 
+        "g2.8xlarge",
         "g2.2xlarge",
         "t2.small",
         "t2.medium",
@@ -107,14 +107,18 @@
   },
   "Mappings" : {
     "AmazonLinux" : {
-      "us-east-1"      : { "AMI" : "ami-e7c96af1"  },
-      "us-west-2"      : { "AMI" : "ami-dfb13ebf"  },
-      "eu-west-1"      : { "AMI" : "ami-6e5d6808"  }
+      "us-east-1"      : { "AMI" : "ami-e47723f2"  },
+      "us-east-2"      : {"AMI"  : "ami-ed3b1d88"  },
+      "us-west-2"      : { "AMI" : "ami-c6dfb2a6"  },
+      "eu-west-1"      : { "AMI" : "ami-df0a1ab9"  },
+      "ap-southeast-2" : { "AMI" : "ami-c1ced9a2"  }
     },
     "Ubuntu" : {
-      "us-east-1"      : { "AMI" : "ami-9548e783"  },
-      "us-west-2"      : { "AMI" : "ami-e9038d89"  },
-      "eu-west-1"      : { "AMI" : "ami-627d4a04"  }
+      "us-east-1"      : { "AMI" : "ami-b67e2aa0"  },
+      "us-east-2"      : { "AMI" : "ami-8d381ee8"  },
+      "us-west-2"      : { "AMI" : "ami-d9deb3b9"  },
+      "eu-west-1"      : { "AMI" : "ami-c50c1ca3"  },
+      "ap-southeast-2" : { "AMI" : "ami-6acdda09"  }
     },
     "SubnetConfig" : {
       "VPC"     : { "CIDR" : "10.0.0.0/16" },
@@ -123,15 +127,18 @@
     },
     "S3" : {
       "us-east-1"      : { "URL" : "https://s3.amazonaws.com/" },
+      "us-east-2"      : { "URL" : "https://s3-us-east-2.amazonaws.com/" },
       "us-west-2"      : { "URL" : "https://s3-us-west-2.amazonaws.com/" },
-      "eu-west-1"      : { "URL" : "https://s3-eu-west-1.amazonaws.com/" }
+      "eu-west-1"      : { "URL" : "https://s3-eu-west-1.amazonaws.com/" },
+      "ap-southeast-2" : { "URL" : "https://s3-ap-southeast-2.amazonaws.com/" }
     },
     "Other" : {
       "S3SourceBucket" : { "BucketNameSuffix" : "-aws-dl-cfn" },
-      "Setup" : { "Filename" : "dl_cfn_setup.py" },
+      "Setup" : { "Filename" : "dl_cfn_setup_v2.py" },
       "LambdaFunction" : { "FileName": "dl_cfn_setup_lambda.zip" },
       "TimeoutValues" : { "WaitConditionTimeout" : "3300", "MasterLaunchTimeout" : "600"},
-      "DefaultUser" : {"AmazonLinux": "ec2-user", "Ubuntu": "ubuntu"}
+      "DefaultUser" : {"AmazonLinux": "ec2-user", "Ubuntu": "ubuntu"},
+      "CfnPath" : {"AmazonLinux": "/opt/aws/bin", "Ubuntu": "/usr/local/bin"}
     }
   },
   "Resources" : {
@@ -176,7 +183,7 @@
           "Statement": [{
             "Effect": "Allow",
               "Action" : [ "autoscaling:DescribeAutoScalingGroups", "autoscaling:SetDesiredCapacity",
-                          "autoscaling:SuspendProcesses", 
+                          "autoscaling:SuspendProcesses",
                           "cloudformation:DescribeStackResource", "cloudformation:SignalResource"
                           ],
             "Resource": "*"
@@ -189,7 +196,7 @@
           "Version": "2012-10-17",
           "Statement": [{
             "Effect": "Allow",
-              "Action" : [ 
+              "Action" : [
                           "sqs:sendmessage"
                           ],
               "Resource" : { "Fn::GetAtt" : [ "MasterQueue", "Arn" ] }
@@ -203,7 +210,7 @@
       "Type": "AWS::Lambda::Permission",
       "Properties": {
         "FunctionName": {
-          "Fn::GetAtt": ["ResourceMetadataLambdaFunction", "Arn"] 
+          "Fn::GetAtt": ["ResourceMetadataLambdaFunction", "Arn"]
         },
         "Action": "lambda:InvokeFunction",
         "Principal": "sns.amazonaws.com",
@@ -287,13 +294,13 @@
           "Tags" : [
             { "Key" : "Name", "Value" : {"Fn::Join" : ["", [{ "Ref" : "AWS::StackName" }, "_SSH" ] ] } }
           ],
-        "SecurityGroupIngress" : [ 
+        "SecurityGroupIngress" : [
             { "IpProtocol" : "tcp", "FromPort" : "22",  "ToPort" : "22",  "CidrIp" : { "Ref" : "SSHLocation" } }
-          ],          
+          ],
         "SecurityGroupEgress" : [
          ]
       }
-    },        
+    },
     "MasterSecurityGroup" : {
       "Type" : "AWS::EC2::SecurityGroup",
       "Properties" : {
@@ -303,55 +310,55 @@
             { "Key" : "Name", "Value" : {"Fn::Join" : ["", [{ "Ref" : "AWS::StackName" }, "_Master" ] ] } }
           ],
         "SecurityGroupIngress" : [
-          ],          
+          ],
         "SecurityGroupEgress" : [
-         ]      
+         ]
       }
     },
     "MasterSecurityIngress1" : {
       "Type" : "AWS::EC2::SecurityGroupIngress",
-      "DependsOn" : ["MasterSecurityGroup"],      
+      "DependsOn" : ["MasterSecurityGroup"],
       "Properties" : {
         "GroupId" : { "Fn::GetAtt": [ "MasterSecurityGroup", "GroupId" ] },
-         "IpProtocol" : "tcp", 
-         "FromPort" : "0", 
+         "IpProtocol" : "tcp",
+         "FromPort" : "0",
          "ToPort" : "65535",
          "SourceSecurityGroupId" :  { "Fn::GetAtt": [ "MasterSecurityGroup", "GroupId" ] }
       }
     },
     "MasterSecurityIngress2" : {
       "Type" : "AWS::EC2::SecurityGroupIngress",
-      "DependsOn" : ["MasterSecurityGroup", "WorkerSecurityGroup"],      
+      "DependsOn" : ["MasterSecurityGroup", "WorkerSecurityGroup"],
       "Properties" : {
         "GroupId" : { "Fn::GetAtt": [ "MasterSecurityGroup", "GroupId" ] },
-         "IpProtocol" : "icmp", 
-         "FromPort" : "-1", 
+         "IpProtocol" : "icmp",
+         "FromPort" : "-1",
          "ToPort" : "-1",
          "SourceSecurityGroupId" :  { "Fn::GetAtt": [ "MasterSecurityGroup", "GroupId" ] }
       }
     },
     "MasterSecurityIngress3" : {
       "Type" : "AWS::EC2::SecurityGroupIngress",
-      "DependsOn" : ["MasterSecurityGroup", "WorkerSecurityGroup"],      
+      "DependsOn" : ["MasterSecurityGroup", "WorkerSecurityGroup"],
       "Properties" : {
         "GroupId" : { "Fn::GetAtt": [ "MasterSecurityGroup", "GroupId" ] },
-         "IpProtocol" : "tcp", 
-         "FromPort" : "0", 
+         "IpProtocol" : "tcp",
+         "FromPort" : "0",
          "ToPort" : "65535",
          "SourceSecurityGroupId" :  { "Fn::GetAtt": [ "WorkerSecurityGroup", "GroupId" ] }
       }
-    },    
+    },
     "MasterSecurityIngress4" : {
       "Type" : "AWS::EC2::SecurityGroupIngress",
-      "DependsOn" : ["MasterSecurityGroup", "WorkerSecurityGroup"],      
+      "DependsOn" : ["MasterSecurityGroup", "WorkerSecurityGroup"],
       "Properties" : {
         "GroupId" : { "Fn::GetAtt": [ "MasterSecurityGroup", "GroupId" ] },
-         "IpProtocol" : "icmp", 
-         "FromPort" : "-1", 
+         "IpProtocol" : "icmp",
+         "FromPort" : "-1",
          "ToPort" : "-1",
          "SourceSecurityGroupId" :  { "Fn::GetAtt": [ "WorkerSecurityGroup", "GroupId" ] }
       }
-    },        
+    },
     "WorkerSecurityGroup" : {
       "Type" : "AWS::EC2::SecurityGroup",
       "DependsOn" : ["MasterSecurityGroup"],
@@ -360,7 +367,7 @@
         "VpcId" : { "Ref" : "Vpc" },
           "Tags" : [
             { "Key" : "Name", "Value" : {"Fn::Join" : ["", [{ "Ref" : "AWS::StackName" }, "_Worker"] ]} }
-          ],                 
+          ],
         "SecurityGroupIngress" : [
             { "IpProtocol" : "tcp", "FromPort" : "0", "ToPort" : "65535", "SourceSecurityGroupId" : { "Ref" : "MasterSecurityGroup" } },
             { "IpProtocol" : "icmp", "FromPort" : "-1", "ToPort" : "-1", "SourceSecurityGroupId" : { "Ref" : "MasterSecurityGroup" } }
@@ -371,22 +378,22 @@
     },
     "WorkerSecurityIngress3" : {
       "Type" : "AWS::EC2::SecurityGroupIngress",
-      "DependsOn" : ["WorkerSecurityGroup"],      
+      "DependsOn" : ["WorkerSecurityGroup"],
       "Properties" : {
         "GroupId" : { "Fn::GetAtt": [ "WorkerSecurityGroup", "GroupId" ] },
-         "IpProtocol" : "tcp", 
-         "FromPort" : "0", 
+         "IpProtocol" : "tcp",
+         "FromPort" : "0",
          "ToPort" : "65535",
          "SourceSecurityGroupId" :  { "Fn::GetAtt": [ "WorkerSecurityGroup", "GroupId" ] }
       }
     },
     "WorkerSecurityIngress4" : {
       "Type" : "AWS::EC2::SecurityGroupIngress",
-      "DependsOn" : ["WorkerSecurityGroup"],      
+      "DependsOn" : ["WorkerSecurityGroup"],
       "Properties" : {
         "GroupId" : { "Fn::GetAtt": [ "WorkerSecurityGroup", "GroupId" ] },
-         "IpProtocol" : "icmp", 
-         "FromPort" : "-1", 
+         "IpProtocol" : "icmp",
+         "FromPort" : "-1",
          "ToPort" : "-1",
          "SourceSecurityGroupId" :  { "Fn::GetAtt": [ "WorkerSecurityGroup", "GroupId" ] }
       }
@@ -429,7 +436,7 @@
         "SubnetId" : { "Ref" : "PrivateSubnet" },
         "SecurityGroups": [ { "Ref": "MountTargetSecurityGroup" } ]
       }
-    },    
+    },
     "WorkerLaunchConfig" : {
       "Type" : "AWS::AutoScaling::LaunchConfiguration",
       "Properties" : {
@@ -443,14 +450,14 @@
           "Ref" : "InstanceProfile"
         },
         "SecurityGroups" : [
-          {"Ref" : "WorkerSecurityGroup"} 
+          {"Ref" : "WorkerSecurityGroup"}
         ],
         "UserData" : {
           "Fn::Base64" : {
-            "Fn::Join" : [ "", 
+            "Fn::Join" : [ "",
               [
                 "#!/bin/bash -xe",
-                "\n",                
+                "\n",
 
                 "# setup ssh-forwarding. ",
                 "sed -i \"s/^#\\(\\s\\+\\)ForwardAgent\\(\\s\\+\\)no/\\ \\1ForwardAgent\\2yes/g\" /etc/ssh/ssh_config",
@@ -460,9 +467,8 @@
                 "\n",
 
                 "# run cfn-init. \n",
-                "export CFN_PATH=\\/opt\\/aws\\/bin",
-                "\n",
-                "$CFN_PATH\\/cfn-init -v --region ", { "Ref" : "AWS::Region" },
+                { "Fn::FindInMap" : [ "Other", "CfnPath", {"Ref" : "ImageType" } ]},
+                "\\/cfn-init -v --region ", { "Ref" : "AWS::Region" },
                 " --configsets Setup ",
                 " -s ",
                 { "Ref" : "AWS::StackId" },
@@ -472,7 +478,7 @@
               ]
             ]
           }
-        },               
+        },
         "KeyName" : {
           "Ref" : "KeyName"
         }
@@ -498,16 +504,16 @@
           },
           "download-setup" :{
             "files" : {
-                "/opt/deeplearning/dl_cfn_setup.py":
+                "/opt/deeplearning/dl_cfn_setup_v2.py":
                 { "source" : { "Fn::Join" : [ "", [ {"Fn::FindInMap" : [ "S3", { "Ref" : "AWS::Region" }, "URL" ]}, {"Fn::Join" : ["", [{ "Ref" : "AWS::Region" }, { "Fn::FindInMap" : [ "Other", "S3SourceBucket", "BucketNameSuffix" ]} ] ]}, "/", { "Fn::FindInMap" : [ "Other", "Setup", "Filename" ]} ] ] } }
             }
           },
           "deeplearning-config" : {
             "commands" : {
               "01_setup" : {
-                  "command" : "python /opt/deeplearning/dl_cfn_setup.py | tee -a /var/log/cloud-init-output.log",
+                  "command" : "python /opt/deeplearning/dl_cfn_setup_v2.py | tee -a /var/log/cloud-init-output.log",
                   "cwd" : "/opt/deeplearning",
-                  "env" : { "AWS_DL_NODE_TYPE" : "Worker", 
+                  "env" : { "AWS_DL_NODE_TYPE" : "Worker",
                             "AWS_DL_MASTER_QUEUE": { "Fn::GetAtt" : [ "MasterQueue", "QueueName" ] },
                             "AWS_DL_WORKER_QUEUE": { "Fn::GetAtt" : [ "WorkerQueue", "QueueName" ] },
                             "AWS_DL_WAITCONDITION_TIMEOUT" : { "Fn::FindInMap" : [ "Other", "TimeoutValues", "WaitConditionTimeout" ]},
@@ -517,7 +523,8 @@
                             "AWS_DL_ROLE_NAME" : {"Fn::Join" : ["", [{ "Ref" : "AWS::StackName" }, "-InstanceRole" ] ] },
                             "AWS_DL_DEFAULT_USER" : { "Fn::FindInMap" : [ "Other", "DefaultUser", {"Ref" : "ImageType" } ]},
                             "AWS_REGION" : { "Ref" : "AWS::Region" },
-                            "EFS_MOUNT" : {"Fn::Join" : ["", ["/", { "Ref" : "EFSMountPoint" } ] ] }
+                            "EFS_MOUNT" : {"Fn::Join" : ["", ["/", { "Ref" : "EFSMountPoint" } ] ] },
+                            "CFN_PATH" : { "Fn::FindInMap" : [ "Other", "CfnPath", {"Ref" : "ImageType" } ]}
                   }
               }
             }
@@ -539,12 +546,12 @@
           "Ref" : "InstanceProfile"
         },
         "SecurityGroups" : [
-          { "Ref" : "MasterSecurityGroup" }, 
+          { "Ref" : "MasterSecurityGroup" },
           { "Ref" : "AdminSSHSecurityGroup" }
         ],
         "UserData" : {
           "Fn::Base64" : {
-            "Fn::Join" : [ "", 
+            "Fn::Join" : [ "",
               [
                 "#!/bin/bash -xe",
                 "\n",
@@ -556,9 +563,8 @@
                 "\n",
 
                 "# run cfn-init. \n",
-                "export CFN_PATH=\\/opt\\/aws\\/bin",
-                "\n",
-                "$CFN_PATH\\/cfn-init -v --region ", { "Ref" : "AWS::Region" },
+                { "Fn::FindInMap" : [ "Other", "CfnPath", {"Ref" : "ImageType" } ]},
+                "\\/cfn-init -v --region ", { "Ref" : "AWS::Region" },
                 " --configsets Setup ",
                 " -s ",
                 { "Ref" : "AWS::StackId" },
@@ -568,10 +574,10 @@
               ]
             ]
           }
-        },        
+        },
         "KeyName" : {
           "Ref" : "KeyName"
-        }        
+        }
       },
       "Metadata" : {
         "AWS::CloudFormation::Init" : {
@@ -594,16 +600,16 @@
           },
           "download-setup" :{
             "files" : {
-                "/opt/deeplearning/dl_cfn_setup.py":
+                "/opt/deeplearning/dl_cfn_setup_v2.py":
                 { "source" : { "Fn::Join" : [ "", [ {"Fn::FindInMap" : [ "S3", { "Ref" : "AWS::Region" }, "URL" ]}, {"Fn::Join" : ["", [{ "Ref" : "AWS::Region" }, { "Fn::FindInMap" : [ "Other", "S3SourceBucket", "BucketNameSuffix" ]} ] ]}, "/", { "Fn::FindInMap" : [ "Other", "Setup", "Filename" ]} ] ] } }
             }
           },
           "deeplearning-config" : {
             "commands" : {
               "01_setup" : {
-                  "command" : "python /opt/deeplearning/dl_cfn_setup.py | tee -a /var/log/cloud-init-output.log",
+                  "command" : "python /opt/deeplearning/dl_cfn_setup_v2.py | tee -a /var/log/cloud-init-output.log",
                   "cwd" : "/opt/deeplearning",
-                  "env" : { "AWS_DL_NODE_TYPE" : "Master", 
+                  "env" : { "AWS_DL_NODE_TYPE" : "Master",
                             "AWS_DL_MASTER_QUEUE": { "Fn::GetAtt" : [ "MasterQueue", "QueueName" ] },
                             "AWS_DL_WORKER_QUEUE": { "Fn::GetAtt" : [ "WorkerQueue", "QueueName" ] },
                             "AWS_DL_WAITCONDITION_TIMEOUT" : { "Fn::FindInMap" : [ "Other", "TimeoutValues", "WaitConditionTimeout" ]},
@@ -613,7 +619,8 @@
                             "AWS_DL_ROLE_NAME" : {"Fn::Join" : ["", [{ "Ref" : "AWS::StackName" }, "-InstanceRole" ] ] },
                             "AWS_DL_DEFAULT_USER" : { "Fn::FindInMap" : [ "Other", "DefaultUser", {"Ref" : "ImageType" } ]},
                             "AWS_REGION" : { "Ref" : "AWS::Region" },
-                            "EFS_MOUNT" : {"Fn::Join" : ["", ["/", { "Ref" : "EFSMountPoint" } ] ] }
+                            "EFS_MOUNT" : {"Fn::Join" : ["", ["/", { "Ref" : "EFSMountPoint" } ] ] },
+                            "CFN_PATH" : { "Fn::FindInMap" : [ "Other", "CfnPath", {"Ref" : "ImageType" } ]}
                   }
               }
             }
@@ -687,7 +694,7 @@
           "Key" : "Name",
           "Value" : {
             "Fn::Join" : ["", [{ "Ref" : "AWS::StackName" }, "-Worker" ] ]
-          },          
+          },
           "PropagateAtLaunch" : true
           },
           {
@@ -718,7 +725,7 @@
           {
             "Endpoint" : {
               "Fn::GetAtt" : [ "ResourceMetadataLambdaFunction", "Arn" ]
-            }, "Protocol" : "lambda" 
+            }, "Protocol" : "lambda"
           }
         ],
         "TopicName" : {"Fn::Join" : ["", [{ "Ref" : "AWS::StackName" }, "-aws-dl-cfn" ] ] }
@@ -748,7 +755,7 @@
           "EnableDnsHostnames" : "true",
           "Tags" : [
             { "Key" : "Name", "Value" : { "Ref" : "AWS::StackName" } }
-          ]     
+          ]
       }
     },
     "InternetGateway" : {
@@ -841,7 +848,7 @@
           { "Key" : "Name", "Value" : { "Ref" : "AWS::StackName" }}
         ]
       }
-    },        
+    },
     "PrivateRoute" : {
       "Type" : "AWS::EC2::Route",
       "Properties" : {
@@ -856,7 +863,7 @@
         "SubnetId" : { "Ref" : "PrivateSubnet" },
         "RouteTableId" : { "Ref" : "PrivateRouteTable" }
       }
-    }            
+    }
   },
   "Outputs" : {
     "AdminSSHSecurityGroup" : {


### PR DESCRIPTION
# Changes
* Upgraded AMI IDs to June release. This consists of MXNet v0.10 and Tensorflow 1.1
* Added support to 2 new AWS Regions - us-east-2, ap-southeast-2
* Fixed issue with cfn-init and cfn-signal utility path. Versioned dl_cfn_setup.py with dl_cfn_setup_v2.py to enable backward compatibility.
* Uploaded required resources in source S3 buckets and set correct permissions.

# Testing Done
AmazonLinux

1. "us-east-1"      : { "AMI" : "ami-e47723f2"  },

Tests
GPU: MXNet, Tensorflow - Passed
CPU: MXNet - Passed
metadata tests: Passed

 2. ”us-east-2"      : {"AMI"  : "ami-ed3b1d88"  },

Tests
GPU: MXNet, Tensorflow - Passed
CPU: MXNet - Passed
metadata tests: Passed

3. "us-west-2"      : { "AMI" : "ami-c6dfb2a6"  },
 
Tests
GPU: MXNet, Tensorflow - Passed
CPU: MXNet - Passed
metadata tests: Passed

4. "eu-west-1"      : { "AMI" : "ami-df0a1ab9"  },
Tests
GPU: MXNet, Tensorflow - Passed
CPU: MXNet - Passed
metadata tests: Passed

5.   "ap-southeast-2" : { "AMI" : "ami-c1ced9a2"  },
Tests
GPU: MXNet, Tensorflow - Passed
CPU: MXNet - Passed
metadata tests: Passed

Ubuntu

1. ”us-east-1"      : { "AMI" : "ami-b67e2aa0"  },

Tests
GPU: MXNet, Tensorflow - Passed
CPU: MXNet - Passed
metadata tests: Passed

2. "us-east-2"      : { "AMI" : "ami-8d381ee8"  },

Tests
GPU: MXNet, Tensorflow - Passed
CPU: MXNet - Passed
metadata tests: Passed

3. "us-west-2"      : { "AMI" : "ami-d9deb3b9"  },

Tests
GPU: MXNet, Tensorflow - Passed
CPU: MXNet - Passed
metadata tests: Passed

4. "eu-west-1"      : { "AMI" : "ami-c50c1ca3"  },

Tests
GPU: MXNet, Tensorflow - Passed
CPU: MXNet - Passed
metadata tests: Passed

5. "ap-southeast-2" : { "AMI" : "ami-6acdda09"  },

Tests
GPU: MXNet, Tensorflow - Passed
CPU: MXNet - Passed
metadata tests: Passed
